### PR TITLE
Add Alamofire example

### DIFF
--- a/Samples/AlamoFire/v5/Alamo.xcodeproj/project.pbxproj
+++ b/Samples/AlamoFire/v5/Alamo.xcodeproj/project.pbxproj
@@ -1,0 +1,606 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CB7E26B42D7469E1007D642B /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = CB7E26B32D7469E1007D642B /* Alamofire */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CB7E26962D7469C1007D642B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CB7E267D2D7469C0007D642B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CB7E26842D7469C0007D642B;
+			remoteInfo = Alamo;
+		};
+		CB7E26A02D7469C1007D642B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CB7E267D2D7469C0007D642B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CB7E26842D7469C0007D642B;
+			remoteInfo = Alamo;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		CB7E26852D7469C0007D642B /* Alamo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alamo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB7E26952D7469C1007D642B /* AlamoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlamoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB7E269F2D7469C1007D642B /* AlamoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlamoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		CB7E26B62D74879A007D642B /* Exceptions for "Alamo" folder in "Alamo" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = CB7E26842D7469C0007D642B /* Alamo */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		CB7E26872D7469C0007D642B /* Alamo */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				CB7E26B62D74879A007D642B /* Exceptions for "Alamo" folder in "Alamo" target */,
+			);
+			path = Alamo;
+			sourceTree = "<group>";
+		};
+		CB7E26982D7469C1007D642B /* AlamoTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = AlamoTests;
+			sourceTree = "<group>";
+		};
+		CB7E26A22D7469C1007D642B /* AlamoUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = AlamoUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CB7E26822D7469C0007D642B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB7E26B42D7469E1007D642B /* Alamofire in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB7E26922D7469C1007D642B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB7E269C2D7469C1007D642B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CB7E267C2D7469C0007D642B = {
+			isa = PBXGroup;
+			children = (
+				CB7E26872D7469C0007D642B /* Alamo */,
+				CB7E26982D7469C1007D642B /* AlamoTests */,
+				CB7E26A22D7469C1007D642B /* AlamoUITests */,
+				CB7E26862D7469C0007D642B /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		CB7E26862D7469C0007D642B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CB7E26852D7469C0007D642B /* Alamo.app */,
+				CB7E26952D7469C1007D642B /* AlamoTests.xctest */,
+				CB7E269F2D7469C1007D642B /* AlamoUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CB7E26842D7469C0007D642B /* Alamo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB7E26A92D7469C1007D642B /* Build configuration list for PBXNativeTarget "Alamo" */;
+			buildPhases = (
+				CB7E26812D7469C0007D642B /* Sources */,
+				CB7E26822D7469C0007D642B /* Frameworks */,
+				CB7E26832D7469C0007D642B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				CB7E26872D7469C0007D642B /* Alamo */,
+			);
+			name = Alamo;
+			packageProductDependencies = (
+				CB7E26B32D7469E1007D642B /* Alamofire */,
+			);
+			productName = Alamo;
+			productReference = CB7E26852D7469C0007D642B /* Alamo.app */;
+			productType = "com.apple.product-type.application";
+		};
+		CB7E26942D7469C1007D642B /* AlamoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB7E26AC2D7469C1007D642B /* Build configuration list for PBXNativeTarget "AlamoTests" */;
+			buildPhases = (
+				CB7E26912D7469C1007D642B /* Sources */,
+				CB7E26922D7469C1007D642B /* Frameworks */,
+				CB7E26932D7469C1007D642B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CB7E26972D7469C1007D642B /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				CB7E26982D7469C1007D642B /* AlamoTests */,
+			);
+			name = AlamoTests;
+			packageProductDependencies = (
+			);
+			productName = AlamoTests;
+			productReference = CB7E26952D7469C1007D642B /* AlamoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		CB7E269E2D7469C1007D642B /* AlamoUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB7E26AF2D7469C1007D642B /* Build configuration list for PBXNativeTarget "AlamoUITests" */;
+			buildPhases = (
+				CB7E269B2D7469C1007D642B /* Sources */,
+				CB7E269C2D7469C1007D642B /* Frameworks */,
+				CB7E269D2D7469C1007D642B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CB7E26A12D7469C1007D642B /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				CB7E26A22D7469C1007D642B /* AlamoUITests */,
+			);
+			name = AlamoUITests;
+			packageProductDependencies = (
+			);
+			productName = AlamoUITests;
+			productReference = CB7E269F2D7469C1007D642B /* AlamoUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CB7E267D2D7469C0007D642B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1620;
+				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+					CB7E26842D7469C0007D642B = {
+						CreatedOnToolsVersion = 16.2;
+					};
+					CB7E26942D7469C1007D642B = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = CB7E26842D7469C0007D642B;
+					};
+					CB7E269E2D7469C1007D642B = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = CB7E26842D7469C0007D642B;
+					};
+				};
+			};
+			buildConfigurationList = CB7E26802D7469C0007D642B /* Build configuration list for PBXProject "Alamo" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CB7E267C2D7469C0007D642B;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				CB7E26B22D7469E1007D642B /* XCRemoteSwiftPackageReference "Alamofire" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = CB7E26862D7469C0007D642B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CB7E26842D7469C0007D642B /* Alamo */,
+				CB7E26942D7469C1007D642B /* AlamoTests */,
+				CB7E269E2D7469C1007D642B /* AlamoUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CB7E26832D7469C0007D642B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB7E26932D7469C1007D642B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB7E269D2D7469C1007D642B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CB7E26812D7469C0007D642B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB7E26912D7469C1007D642B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB7E269B2D7469C1007D642B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CB7E26972D7469C1007D642B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CB7E26842D7469C0007D642B /* Alamo */;
+			targetProxy = CB7E26962D7469C1007D642B /* PBXContainerItemProxy */;
+		};
+		CB7E26A12D7469C1007D642B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CB7E26842D7469C0007D642B /* Alamo */;
+			targetProxy = CB7E26A02D7469C1007D642B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		CB7E26A72D7469C1007D642B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		CB7E26A82D7469C1007D642B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CB7E26AA2D7469C1007D642B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Alamo/Preview Content\"";
+				DEVELOPMENT_TEAM = KCACRD7592;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Alamo/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hiroakit.example.ios.Alamo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CB7E26AB2D7469C1007D642B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Alamo/Preview Content\"";
+				DEVELOPMENT_TEAM = KCACRD7592;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Alamo/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hiroakit.example.ios.Alamo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		CB7E26AD2D7469C1007D642B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KCACRD7592;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hiroakit.example.ios.AlamoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Alamo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Alamo";
+			};
+			name = Debug;
+		};
+		CB7E26AE2D7469C1007D642B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KCACRD7592;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hiroakit.example.ios.AlamoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Alamo.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Alamo";
+			};
+			name = Release;
+		};
+		CB7E26B02D7469C1007D642B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KCACRD7592;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hiroakit.example.ios.AlamoUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Alamo;
+			};
+			name = Debug;
+		};
+		CB7E26B12D7469C1007D642B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KCACRD7592;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hiroakit.example.ios.AlamoUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Alamo;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CB7E26802D7469C0007D642B /* Build configuration list for PBXProject "Alamo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB7E26A72D7469C1007D642B /* Debug */,
+				CB7E26A82D7469C1007D642B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB7E26A92D7469C1007D642B /* Build configuration list for PBXNativeTarget "Alamo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB7E26AA2D7469C1007D642B /* Debug */,
+				CB7E26AB2D7469C1007D642B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB7E26AC2D7469C1007D642B /* Build configuration list for PBXNativeTarget "AlamoTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB7E26AD2D7469C1007D642B /* Debug */,
+				CB7E26AE2D7469C1007D642B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB7E26AF2D7469C1007D642B /* Build configuration list for PBXNativeTarget "AlamoUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB7E26B02D7469C1007D642B /* Debug */,
+				CB7E26B12D7469C1007D642B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		CB7E26B22D7469E1007D642B /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = exactVersion;
+				version = 5.10.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		CB7E26B32D7469E1007D642B /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CB7E26B22D7469E1007D642B /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = CB7E267D2D7469C0007D642B /* Project object */;
+}

--- a/Samples/AlamoFire/v5/Alamo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Samples/AlamoFire/v5/Alamo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Samples/AlamoFire/v5/Alamo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Samples/AlamoFire/v5/Alamo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "e8f130fe30ac6cdc940ef06ee1e8535e9f46ffee6aeead1722b9525562f6ce08",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Samples/AlamoFire/v5/Alamo/AlamoApp.swift
+++ b/Samples/AlamoFire/v5/Alamo/AlamoApp.swift
@@ -1,0 +1,17 @@
+//
+//  AlamoApp.swift
+//  Alamo
+//
+//  Created by hiroakit on 2025/03/02.
+//
+
+import SwiftUI
+
+@main
+struct AlamoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Samples/AlamoFire/v5/Alamo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Samples/AlamoFire/v5/Alamo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/AlamoFire/v5/Alamo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Samples/AlamoFire/v5/Alamo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/AlamoFire/v5/Alamo/Assets.xcassets/Contents.json
+++ b/Samples/AlamoFire/v5/Alamo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/AlamoFire/v5/Alamo/Info.plist
+++ b/Samples/AlamoFire/v5/Alamo/Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Samples/AlamoFire/v5/Alamo/Model/Movie.swift
+++ b/Samples/AlamoFire/v5/Alamo/Model/Movie.swift
@@ -1,0 +1,27 @@
+//
+//  Movie.swift
+//  Alamo
+//
+//  Created by hiroakit on 2025/03/09.
+//
+
+import SwiftUI
+
+struct Movie: Transferable {
+    let url: URL
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(contentType: .movie) { movie in
+            SentTransferredFile(movie.url)
+        } importing: { received in
+            let copy = URL.documentsDirectory.appending(path: received.file.lastPathComponent)
+
+            if FileManager.default.fileExists(atPath: copy.path()) {
+                try FileManager.default.removeItem(at: copy)
+            }
+
+            try FileManager.default.copyItem(at: received.file, to: copy)
+            return Self.init(url: copy)
+        }
+    }
+}

--- a/Samples/AlamoFire/v5/Alamo/Model/MovieService.swift
+++ b/Samples/AlamoFire/v5/Alamo/Model/MovieService.swift
@@ -1,0 +1,60 @@
+//
+//  MovieService.swift
+//  Alamo
+//
+//  Created by hiroakit on 2025/03/09.
+//
+
+
+import Foundation
+import Alamofire
+
+class MovieService {
+    private let networkManager: NetworkManager
+
+    init(networkManager: NetworkManager) {
+        self.networkManager = networkManager
+    }
+
+    func uploadFiles(_ items: [URL], completion: @escaping (Bool, Int?) -> Void) {
+        let baseUrl = networkManager.getApiBaseUrl()
+        let uploadURL = "\(baseUrl)/api/v1/movie"
+        
+        var files: [(String, Data, String)] = []
+        
+        for (index, url) in items.enumerated() {
+            if let data = try? Data(contentsOf: url) {
+                files.append(("file\(index + 1).mp4", data, "video/mp4"))
+            }
+        }
+
+        networkManager.session.upload(multipartFormData: { multipartFormData in
+            for file in files {
+                multipartFormData.append(file.1, withName: "files", fileName: file.0, mimeType: file.2)
+            }
+        }, to: uploadURL, method: .post)
+        .response { response in
+            switch response.result {
+            case .success:
+                // HTTP ステータスコードを取得
+                if let statusCode = response.response?.statusCode {
+                    if (200...299).contains(statusCode) {
+                        print("Upload successful: HTTP \(statusCode)")
+                        completion(true, statusCode)
+                    } else {
+                        print("Upload failed with status code: HTTP \(statusCode)")
+                        completion(false, statusCode)
+                    }
+                } else {
+                    print("Upload failed: No HTTP response")
+                    completion(false, nil)
+                }                
+            case .failure(let error):
+                print("Upload request failed: \(error.localizedDescription)")
+                let statusCode = response.response?.statusCode
+                completion(false, statusCode)
+            }
+        }
+    }
+
+}

--- a/Samples/AlamoFire/v5/Alamo/Model/NetworkManager.swift
+++ b/Samples/AlamoFire/v5/Alamo/Model/NetworkManager.swift
@@ -1,0 +1,27 @@
+//
+//  NetworkManager.swift
+//  Alamo
+//
+//  Created by hiroakit on 2025/03/09.
+//
+
+import Foundation
+import Alamofire
+
+class NetworkManager {
+    let session: Session
+    private let placeholderApiHostUrl: String = "https://api.example.com"
+
+    init() {
+        let apiBaseUrl = UserDefaults.standard.string(forKey: "apiHost") ?? self.placeholderApiHostUrl
+        let host = URL(string: apiBaseUrl)?.host ?? "api.example.com"
+        print("Using API Host: \(host)")
+        let manager = ServerTrustManager(evaluators: [host: DisabledTrustEvaluator()])
+        let configuration = URLSessionConfiguration.af.default
+        self.session = Session(configuration: configuration, serverTrustManager: manager)
+    }
+    
+    func getApiBaseUrl() -> String {
+        return UserDefaults.standard.string(forKey: "apiHost") ?? self.placeholderApiHostUrl
+    }
+}

--- a/Samples/AlamoFire/v5/Alamo/Model/WeatherForecast.swift
+++ b/Samples/AlamoFire/v5/Alamo/Model/WeatherForecast.swift
@@ -1,0 +1,13 @@
+//
+//  WeatherForecast.swift
+//  Alamo
+//
+//  Created by hiroakit on 2025/03/09.
+//
+
+import Foundation
+
+struct WeatherForecast: Identifiable, Decodable {
+    var id: UUID { UUID() }
+    let summary: String
+}

--- a/Samples/AlamoFire/v5/Alamo/Model/WeatherService.swift
+++ b/Samples/AlamoFire/v5/Alamo/Model/WeatherService.swift
@@ -1,0 +1,35 @@
+//
+//  WeatherService.swift
+//  Alamo
+//
+//  Created by hiroakit on 2025/03/09.
+//
+
+
+import Foundation
+import Alamofire
+
+class WeatherService {
+    private let networkManager: NetworkManager
+
+    init(networkManager: NetworkManager) {
+        self.networkManager = networkManager
+    }
+
+    func fetchWeather(completion: @escaping ([WeatherForecast]) -> Void) {
+        let baseUrl = networkManager.getApiBaseUrl()
+        let url = "\(baseUrl)/api/v1/weatherforecast"
+        
+        networkManager.session.request(url)
+            .validate()
+            .responseDecodable(of: [WeatherForecast].self) { response in
+                switch response.result {
+                case .success(let data):
+                    completion(data)
+                case .failure(let error):
+                    print("Failed to fetch weather data: \(error.localizedDescription)")
+                    completion([])
+                }
+            }
+    }
+}

--- a/Samples/AlamoFire/v5/Alamo/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Samples/AlamoFire/v5/Alamo/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/AlamoFire/v5/Alamo/View/ContentView.swift
+++ b/Samples/AlamoFire/v5/Alamo/View/ContentView.swift
@@ -1,0 +1,111 @@
+//
+//  ContentView.swift
+//  Alamo
+//
+//  Created by hiroakit on 2025/03/02.
+//
+
+import SwiftUI
+import PhotosUI
+import AVKit
+
+struct ContentView: View {
+    @StateObject private var viewModel: ContentViewModel
+    @State private var selectedItems: [PhotosPickerItem] = []
+    @State private var isSettingsPresented = false
+    
+    init() {
+        let networkManager = NetworkManager()
+        _viewModel = StateObject(wrappedValue: ContentViewModel(networkManager: networkManager))
+    }
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                Text(viewModel.uploadStatus)
+                    .onAppear {
+                        if selectedItems.count < 1 {
+                            viewModel.uploadStatus = "No video selected"
+                        }
+                    }
+                HStack {
+                    PhotosPicker(selection: $selectedItems, maxSelectionCount: 5, matching: .videos) {
+                        Text("Select videos")
+                            .padding()
+                            .background(Color.blue)
+                            .foregroundColor(.white)
+                            .cornerRadius(10)
+                    }
+                    .onChange(of: selectedItems) { _, newItems in
+                        viewModel.uploadStatus = ""
+                        if selectedItems.count < 1 {
+                            viewModel.uploadStatus = "No video selected"
+                        }
+                        viewModel.loadVideos(from: newItems)
+                    }
+
+                    Button(action: {
+                        viewModel.uploadFiles()
+                    }) {
+                        HStack {
+                            if viewModel.isUploading {
+                                ProgressView()
+                                    .padding(.trailing, 5)
+                            }
+                            Text(viewModel.isUploading ? "Uploading..." : "Upload Files")
+                        }
+                        .padding()
+                        .background(viewModel.isUploading ? Color.gray : Color.green)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                    }
+                    .disabled(viewModel.isUploading)
+                }
+                ScrollView(.horizontal) {
+                    HStack {
+                        ForEach(viewModel.selectedVideos, id: \.self) { url in
+                            VideoPlayer(player: AVPlayer(url: url))
+                                .scaledToFit()
+                                .frame(width: 150, height: 150)
+                                .cornerRadius(10)
+                                .padding()
+                        }
+                    }
+                }
+                
+                Button("Fetch Weather") {
+                    viewModel.fetchWeather()
+                }
+                .padding()
+                .background(Color.blue)
+                .foregroundColor(.white)
+                .cornerRadius(10)
+                List(viewModel.weatherData) { weather in
+                    VStack(alignment: .leading) {
+                        Text(weather.summary)
+                    }
+                }
+            }
+            .padding()
+            .navigationTitle("API Testing")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        isSettingsPresented = true
+                    }) {
+                        Image(systemName: "gear")
+                            .imageScale(.large)
+                    }
+                }
+            }
+            .sheet(isPresented: $isSettingsPresented) {
+                SettingsView()
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Samples/AlamoFire/v5/Alamo/View/SettingsView.swift
+++ b/Samples/AlamoFire/v5/Alamo/View/SettingsView.swift
@@ -1,0 +1,41 @@
+//
+//  SettingsView.swift
+//  Alamo
+//
+//  Created by hiroakit on 2025/03/09.
+//
+
+
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("apiHost") private var apiHost: String = ""
+    @Environment(\.presentationMode) private var presentationMode
+
+    var body: some View {
+        NavigationStack {
+            VStack {
+                Text("API Host")
+                    .font(.headline)
+                TextField("https://api.example.com", text: $apiHost)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+                Text("Current API Host: \(apiHost) \nRestart the app after changing the API Host.")
+                    .foregroundColor(.gray)
+                    .padding()
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Configuration")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Close") {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Samples/AlamoFire/v5/Alamo/ViewModel/ContentViewModel.swift
+++ b/Samples/AlamoFire/v5/Alamo/ViewModel/ContentViewModel.swift
@@ -1,0 +1,75 @@
+//
+//  WeatherViewModel.swift
+//  Alamo
+//
+//  Created by hiroakit on 2025/03/09.
+//
+
+
+import SwiftUI
+import PhotosUI
+
+@MainActor
+class ContentViewModel: ObservableObject {
+    @Published var weatherData: [WeatherForecast] = []
+    @Published var selectedVideos: [URL] = []
+    @Published var uploadStatus: String = ""
+    @Published var isUploading: Bool = false
+    private let weatherService: WeatherService
+    private let movieService: MovieService
+    
+    init(networkManager: NetworkManager) {
+        self.weatherService = WeatherService(networkManager: networkManager)
+        self.movieService = MovieService(networkManager: networkManager)
+    }
+    
+    func fetchWeather() {
+        weatherService.fetchWeather { [weak self] data in
+            DispatchQueue.main.async {
+                self?.weatherData = data
+            }
+        }
+    }
+    
+    func uploadFiles() {
+        guard !selectedVideos.isEmpty else {
+            uploadStatus = "No video selected"
+            return
+        }
+        guard !isUploading else {
+            return
+        }
+        isUploading = true
+        uploadStatus = "Uploading......"
+        
+        movieService.uploadFiles(selectedVideos) { [weak self] success, statusCode in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                
+                if success {
+                    self.uploadStatus = "Upload Successful（HTTP \(statusCode ?? 0)）"
+                } else {
+                    if let statusCode = statusCode {
+                        self.uploadStatus = "Upload Failed（HTTP \(statusCode)）"
+                    } else {
+                        self.uploadStatus = "Network error occurred"
+                    }
+                }
+                self.isUploading = false
+            }
+        }
+    }
+    
+    func loadVideos(from items: [PhotosPickerItem]) {
+        Task {
+            self.selectedVideos = []
+
+            for item in items {
+                if let movie = try? await item.loadTransferable(type: Movie.self) {
+                    self.selectedVideos.append(movie.url)
+                    print("Selected video: \(movie.url)")
+                }
+            }
+        }
+    }
+}

--- a/Samples/AlamoFire/v5/AlamoTests/AlamoTests.swift
+++ b/Samples/AlamoFire/v5/AlamoTests/AlamoTests.swift
@@ -1,0 +1,17 @@
+//
+//  AlamoTests.swift
+//  AlamoTests
+//
+//  Created by hiroakit on 2025/03/02.
+//
+
+import Testing
+@testable import Alamo
+
+struct AlamoTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/Samples/AlamoFire/v5/AlamoUITests/AlamoUITests.swift
+++ b/Samples/AlamoFire/v5/AlamoUITests/AlamoUITests.swift
@@ -1,0 +1,43 @@
+//
+//  AlamoUITests.swift
+//  AlamoUITests
+//
+//  Created by hiroakit on 2025/03/02.
+//
+
+import XCTest
+
+final class AlamoUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/Samples/AlamoFire/v5/AlamoUITests/AlamoUITestsLaunchTests.swift
+++ b/Samples/AlamoFire/v5/AlamoUITests/AlamoUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  AlamoUITestsLaunchTests.swift
+//  AlamoUITests
+//
+//  Created by hiroakit on 2025/03/02.
+//
+
+import XCTest
+
+final class AlamoUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
# Overview

Added Alamo App, which utilizes Alamofire.

- [Alamofire v5.10.2 ](https://github.com/Alamofire/Alamofire/releases/tag/5.10.2)

# Usage

1. Run the Example API
    1. Open `./Samples/ExampleApi` in VSCode.
    2. Setup a Self-signed certificate ([Instructions](https://github.com/hiroakit/iOS-Swift-Playgrounds/blob/main/Samples/ExampleApi/README.md#self-signed-certificate)).
    3. Press F5 in VSCode to launch the Example API.
2. Run the Alamo App
    1. Open `./Samples/AlamoFire/v5/Alamo.xcodeproj` in Xcode.
    2. Build the project.
    3. Configure the API Host in Alamo App's Config View.
3. Upload a video
    - Select a video in the Alamo App and press the Upload button to send it to the Example API.